### PR TITLE
Features/multi split

### DIFF
--- a/strutil.h
+++ b/strutil.h
@@ -1,6 +1,6 @@
 /*
- * strutil v1.0.1 - header-only string utility library 
- * 
+ * strutil v1.0.1 - header-only string utility library
+ *
  * Copyright (C) 2020 Tomasz Galaj & SomeRandomDev49
  */
 
@@ -9,14 +9,14 @@
  *
  *  @mainpage strutil documentation
  *  @see https://github.com/Shot511/strutil
- * 
+ *
  *  @copyright  Copyright (C) 2020 Tomasz Galaj & SomeRandomDev49
  *  @file       strutil.h
  *  @brief      Library public interface header
  *
  ******************************************************************************
  */
- 
+
 #pragma once
 
 #include <algorithm>
@@ -30,7 +30,7 @@
 namespace strutil
 {
     /**
-     * @brief Converts any datatype into std::string. 
+     * @brief Converts any datatype into std::string.
      *        Datatype must support << operator.
      * @tparam T
      * @param value - will be converted into std::string.
@@ -252,6 +252,17 @@ namespace strutil
     }
 
     /**
+     * @brief Checks if std::string str ends with specified character.
+     * @param str - input std::string that will be checked.
+     * @param suffix - searched character in str.
+     * @return True if ends with character, false otherwise.
+     */
+    static inline bool ends_with(const std::string & str, const char suffix)
+    {
+        return (str.size() > 0) && (*(str.end()-1) == suffix);
+    }
+
+    /**
      * @brief Checks if std::string str starts with specified prefix.
      * @param str - input std::string that will be checked.
      * @param prefix - searched prefix in str.
@@ -260,6 +271,17 @@ namespace strutil
     static inline bool starts_with(const std::string & str, const std::string & prefix)
     {
         return str.find(prefix) == 0;
+    }
+
+    /**
+     * @brief Checks if std::string str starts with specified character.
+     * @param str - input std::string that will be checked.
+     * @param prefix - searched character in str.
+     * @return True if starts with character, false otherwise.
+     */
+    static inline bool starts_with(const std::string & str, const char prefix)
+    {
+        return (str.size() > 0) && (str[0] == prefix);
     }
 
     /**
@@ -279,9 +301,14 @@ namespace strutil
             tokens.push_back(token);
         }
 
+        // Match semantics of split(str,str)
+        if (str.size() == 0 || ends_with(str, delim)) {
+            tokens.push_back("");
+        }
+
         return tokens;
     }
- 
+
     /**
      * @brief Splits input std::string str according to input std::string delim.
      *        Taken from: https://stackoverflow.com/a/46931770/1892346.
@@ -295,7 +322,7 @@ namespace strutil
         std::string token;
         std::vector<std::string> tokens;
 
-        while ((pos_end = str.find(delim, pos_start)) != std::string::npos) 
+        while ((pos_end = str.find(delim, pos_start)) != std::string::npos)
         {
             token = str.substr(pos_start, pos_end - pos_start);
             pos_start = pos_end + delim_len;
@@ -307,7 +334,7 @@ namespace strutil
     }
 
     /**
-     * @brief Joins all elements of std::vector tokens of arbitrary datatypes 
+     * @brief Joins all elements of std::vector tokens of arbitrary datatypes
      *        into one std::string with delimiter delim.
      * @tparam T - arbitrary datatype.
      * @param tokens - vector of tokens.

--- a/strutil.h
+++ b/strutil.h
@@ -405,6 +405,28 @@ namespace strutil
     }
 
     /**
+     * @brief Inplace removal of all empty strings in a vector<string>
+     * @param tokens - vector of strings.
+     */
+    static inline void drop_empty(std::vector<std::string> & tokens)
+    {
+        auto last = std::remove_if(tokens.begin(), tokens.end(),
+                                   [](const std::string& s){ return s.size() == 0; });
+        tokens.erase(last, tokens.end());
+    }
+
+    /**
+     * @brief Inplace removal of all empty strings in a vector<string>
+     * @param tokens - vector of strings.
+     * @return vector of non-empty tokens.
+     */
+    static inline std::vector<std::string> drop_empty_copy(std::vector<std::string> tokens)
+    {
+        drop_empty(tokens);
+        return tokens;
+    }
+
+    /**
      * @brief Creates new std::string with repeated n times substring str.
      * @param str - substring that needs to be repeated.
      * @param n - number of iterations.

--- a/strutil.h
+++ b/strutil.h
@@ -94,6 +94,28 @@ namespace strutil
     }
 
     /**
+     * @brief Checks if input std::string str contains specified substring.
+     * @param str - std::string to be checked.
+     * @param substring - searched substring.
+     * @return True if substring was found in str, false otherwise.
+     */
+    static inline bool contains(const std::string & str, const std::string & substring)
+    {
+        return str.find(substring) != std::string::npos;
+    }
+
+    /**
+     * @brief Checks if input std::string str contains specified character.
+     * @param str - std::string to be checked.
+     * @param character - searched character.
+     * @return True if character was found in str, false otherwise.
+     */
+    static inline bool contains(const std::string & str, const char character)
+    {
+        return contains(str, std::string(1,character));
+    }
+
+    /**
      * @brief Compares two std::strings ignoring their case (lower/upper).
      * @param str1 - std::string to compare
      * @param str2 - std::string to compare
@@ -312,7 +334,7 @@ namespace strutil
     /**
      * @brief Splits input std::string str according to input std::string delim.
      *        Taken from: https://stackoverflow.com/a/46931770/1892346.
-     * @param str - std::string that will be splitted.
+     * @param str - std::string that will be split.
      * @param delim - the delimiter.
      * @return std::vector<std::string> that contains all splitted tokens.
      */
@@ -327,6 +349,30 @@ namespace strutil
             token = str.substr(pos_start, pos_end - pos_start);
             pos_start = pos_end + delim_len;
             tokens.push_back(token);
+        }
+
+        tokens.push_back(str.substr(pos_start));
+        return tokens;
+    }
+
+    /**
+     * @brief Splits input string using any delimiter in the given set.
+     * @param str - std::string that will be split.
+     * @param delims - the set of delimiter characters.
+     * @return vector of resulting tokens.
+     */
+    static inline std::vector<std::string> split_any(const std::string & str, const std::string & delims)
+    {
+        std::string token;
+        std::vector<std::string> tokens;
+
+        size_t pos_start = 0;
+        for (size_t pos_end = 0; pos_end < str.length(); ++pos_end) {
+            if (contains(delims, str[pos_end])) {
+                token = str.substr(pos_start, pos_end - pos_start);
+                tokens.push_back(token);
+                pos_start = pos_end + 1;
+            }
         }
 
         tokens.push_back(str.substr(pos_start));
@@ -385,17 +431,6 @@ namespace strutil
     static inline std::string repeat(char c, unsigned n)
     {
         return std::string(n, c);
-    }
-
-    /**
-     * @brief Checks if input std::string str contains specified substring.
-     * @param str - std::string to be checked.
-     * @param substring - searched substring.
-     * @return True if substring was found in str, false otherwise.
-     */
-    static inline bool contains(const std::string & str, const std::string & substring)
-    {
-        return str.find(substring) != std::string::npos;
     }
 
     /**

--- a/tests/test_cases.cpp
+++ b/tests/test_cases.cpp
@@ -386,6 +386,26 @@ TEST(Splitting, join)
     EXPECT_EQ(str2, strutil::join<unsigned>(tokens2, "|"));
 }
 
+TEST(Splitting, drop_empty)
+{
+    std::vector<std::string> tokens = { "t1", "t2", "", "t4", "" };
+    strutil::drop_empty(tokens);
+    ASSERT_EQ(tokens.size(), 3);
+    ASSERT_EQ(tokens[0], "t1");
+    ASSERT_EQ(tokens[1], "t2");
+    ASSERT_EQ(tokens[2], "t4");
+}
+
+TEST(Splitting, drop_empty_copy)
+{
+    std::vector<std::string> tokens = { "t1", "t2", "", "t4", "" };
+    auto res = strutil::drop_empty_copy(tokens);
+    ASSERT_EQ(res.size(), 3);
+    ASSERT_EQ(res[0], "t1");
+    ASSERT_EQ(res[1], "t2");
+    ASSERT_EQ(res[2], "t4");
+}
+
 /*
  * Text manipulation tests
  */

--- a/tests/test_cases.cpp
+++ b/tests/test_cases.cpp
@@ -64,10 +64,16 @@ TEST(Compare, ends_with_char)
     EXPECT_EQ(false, strutil::ends_with("", 'm'));
 }
 
-TEST(Compare, contains)
+TEST(Compare, contains_str)
 {
     EXPECT_EQ(true, strutil::contains("DiffuseTexture_m", "fuse"));
     EXPECT_EQ(false, strutil::contains("DiffuseTexture_m", "fuser"));
+}
+
+TEST(Compare, contains_char)
+{
+    EXPECT_EQ(true, strutil::contains("DiffuseTexture_m", 'f'));
+    EXPECT_EQ(false, strutil::contains("DiffuseTexture_m", 'z'));
 }
 
 TEST(Compare, matches)
@@ -320,6 +326,51 @@ TEST(Splitting, split_string_delim)
     {
         EXPECT_EQ(expected[i], res[i]);
     }
+}
+
+TEST(Splitting, split_any)
+{
+    std::vector<std::string> res;
+
+    // Basic usage
+    res = strutil::split_any("abc,def|ghi jkl", ",| ");
+    ASSERT_EQ(res.size(), 4);
+    EXPECT_EQ(res[0], "abc");
+    EXPECT_EQ(res[1], "def");
+    EXPECT_EQ(res[2], "ghi");
+    EXPECT_EQ(res[3], "jkl");
+
+    // Empty input => empty string
+    ASSERT_EQ(strutil::split_any("", ",:")[0], "");
+
+    // No matches => original string
+    res = strutil::split_any("abc_123", ",; ");
+    ASSERT_EQ(res.size(), 1);
+    EXPECT_EQ(res[0], "abc_123");
+
+    // Empty delimiters => original string
+    res = strutil::split_any("abc;def", "");
+    ASSERT_EQ(res.size(), 1);
+    EXPECT_EQ(res[0], "abc;def");
+
+    // Leading delimiters => leading empty string
+    res = strutil::split_any(";abc", ",; ");
+    ASSERT_EQ(res.size(), 2);
+    ASSERT_EQ(res[0], "");
+    ASSERT_EQ(res[1], "abc");
+
+    // Trailing delimiters => trailing empty string
+    res = strutil::split_any("abc;", ",; ");
+    ASSERT_EQ(res.size(), 2);
+    ASSERT_EQ(res[0], "abc");
+    ASSERT_EQ(res[1], "");
+
+    // Consecutive delimiters => repeated empty strings
+    res = strutil::split_any("abc,;123", ",;");
+    ASSERT_EQ(res.size(), 3);
+    EXPECT_EQ(res[0], "abc");
+    EXPECT_EQ(res[1], "");
+    EXPECT_EQ(res[2], "123");
 }
 
 TEST(Splitting, join)

--- a/tests/test_cases.cpp
+++ b/tests/test_cases.cpp
@@ -20,22 +20,48 @@ TEST(Compare, compare_ignore_case)
     EXPECT_EQ(false, strutil::compare_ignore_case(str2, str3));
 }
 
-TEST(Compare, starts_with)
+TEST(Compare, starts_with_str)
 {
     EXPECT_EQ(true, strutil::starts_with("m_DiffuseTexture", "m_"));
     EXPECT_EQ(true, strutil::starts_with("This is a simple test case", "This "));
 
     EXPECT_EQ(false, strutil::starts_with("p_DiffuseTexture", "m_"));
     EXPECT_EQ(false, strutil::starts_with("This is a simple test case", "his "));
+
+    EXPECT_EQ(false, strutil::starts_with("", "m_"));
 }
 
-TEST(Compare, ends_with)
+TEST(Compare, starts_with_char)
+{
+    EXPECT_EQ(true, strutil::starts_with("m_DiffuseTexture", 'm'));
+    EXPECT_EQ(true, strutil::starts_with("This is a simple test case", 'T'));
+
+    EXPECT_EQ(false, strutil::starts_with("p_DiffuseTexture", 'm'));
+    EXPECT_EQ(false, strutil::starts_with("This is a simple test case", 'h'));
+
+    EXPECT_EQ(false, strutil::starts_with("", 'm'));
+}
+
+TEST(Compare, ends_with_str)
 {
     EXPECT_EQ(true, strutil::ends_with("DiffuseTexture_m", "_m"));
     EXPECT_EQ(true, strutil::ends_with("This is a simple test case", " test case"));
 
     EXPECT_EQ(false, strutil::ends_with("DiffuseTexture_p", "_m"));
     EXPECT_EQ(false, strutil::ends_with("This is a simple test case", "test cas"));
+
+    EXPECT_EQ(false, strutil::ends_with("", "_m"));
+}
+
+TEST(Compare, ends_with_char)
+{
+    EXPECT_EQ(true, strutil::ends_with("DiffuseTexture_m", 'm'));
+    EXPECT_EQ(true, strutil::ends_with("This is a simple test case", 'e'));
+
+    EXPECT_EQ(false, strutil::ends_with("DiffuseTexture_p", 'm'));
+    EXPECT_EQ(false, strutil::ends_with("This is a simple test case", 's'));
+
+    EXPECT_EQ(false, strutil::ends_with("", 'm'));
 }
 
 TEST(Compare, contains)
@@ -213,30 +239,86 @@ TEST(Parsing, string_to_neg_bool)
 TEST(Splitting, split_char_delim)
 {
     std::string str1 = "asdf;asdfgh;asdfghjk";
-
     std::vector<std::string> res = strutil::split(str1, ';');
     std::vector<std::string> expected = { "asdf", "asdfgh", "asdfghjk" };
-
     ASSERT_EQ(res.size(), expected.size()) << "Vectors are of unequal length";
-
     for (unsigned i = 0; i < res.size(); ++i)
     {
         EXPECT_EQ(expected[i], res[i]) << "Vectors differ at index " << i;
+    }
+
+    // Empty input => empty string
+    res = strutil::split("", ';');
+    ASSERT_EQ(res.size(), 1);
+    EXPECT_EQ(res[0], "");
+
+    // No matches => original string
+    res = strutil::split(str1, ',');
+    ASSERT_EQ(res.size(), 1);
+    EXPECT_EQ(res[0], str1);
+
+    // Leading delimiter => leading empty string
+    res = strutil::split(";abc", ';');
+    ASSERT_EQ(res.size(), 2);
+    EXPECT_EQ(res[0], "");
+    EXPECT_EQ(res[1], "abc");
+
+    // Trailing delimiter => trailing empty string
+    res = strutil::split("abc;", ';');
+    ASSERT_EQ(res.size(), 2);
+    EXPECT_EQ(res[0], "abc");
+    EXPECT_EQ(res[1], "");
+
+    // Repeated delimiters => repeated empty strings
+    res = strutil::split("abc;;;def", ';');
+    expected = { "abc", "", "", "def" };
+    ASSERT_EQ(res.size(), expected.size());
+    for (unsigned i = 0; i < res.size(); ++i)
+    {
+        EXPECT_EQ(expected[i], res[i]);
     }
 }
 
 TEST(Splitting, split_string_delim)
 {
     std::string str1 = "asdf>=asdfgh>=asdfghjk";
-
     std::vector<std::string> res = strutil::split(str1, ">=");
     std::vector<std::string> expected = { "asdf", "asdfgh", "asdfghjk" };
-
     ASSERT_EQ(res.size(), expected.size()) << "Vectors are of unequal length";
-
     for (unsigned i = 0; i < res.size(); ++i)
     {
         EXPECT_EQ(expected[i], res[i]) << "Vectors differ at index " << i;
+    }
+
+    // Empty input => empty string
+    res = strutil::split("", ">=");
+    ASSERT_EQ(res.size(), 1);
+    EXPECT_EQ(res[0], "");
+
+    // No matches => original string
+    res = strutil::split(str1, "<>");
+    ASSERT_EQ(res.size(), 1);
+    EXPECT_EQ(res[0], str1);
+
+    // Leading delimiter => leading empty string
+    res = strutil::split(">=abc", ">=");
+    ASSERT_EQ(res.size(), 2);
+    EXPECT_EQ(res[0], "");
+    EXPECT_EQ(res[1], "abc");
+
+    // Trailing delimiter => trailing empty string
+    res = strutil::split("abc>=", ">=");
+    ASSERT_EQ(res.size(), 2);
+    EXPECT_EQ(res[0], "abc");
+    EXPECT_EQ(res[1], "");
+
+    // Repeated delimiters => repeated empty strings
+    res = strutil::split("abc>=>=>=def", ">=");
+    expected = { "abc", "", "", "def" };
+    ASSERT_EQ(res.size(), expected.size());
+    for (unsigned i = 0; i < res.size(); ++i)
+    {
+        EXPECT_EQ(expected[i], res[i]);
     }
 }
 


### PR DESCRIPTION
Addresses #2. 

This add a method `split_any(str,delims)`, which will split an input string using any of the characters in `delims`. A utility method, `drop_empty[_copy]`, is provided for removing empty strings generated by repeated delimiters. This allows concise, flexible parsing of lists such that we can accept multiple possible delimiters and be robust to variations in whitespace:
```cpp
auto tokens = drop_empty_copy(split_any("abc, 123; def , 456 splat", ",; "));
// {"abc", "123", "def", "456", "splat"}
```

This also makes some ancillary improvements: uniform split semantics, additional overloads for `start_with`/`ends_with`, additional overloads for `contains`. All updates are exercised in the test harness.