### PR TITLE
Performance improvements

### DIFF
--- a/strutil.h
+++ b/strutil.h
@@ -294,9 +294,9 @@ namespace strutil
      */
     static inline bool ends_with(const std::string & str, const std::string & suffix)
     {
-        const auto pos = str.rfind(suffix);
-
-        return (pos != std::string::npos) && (pos == (str.length() - suffix.length()));
+        const auto suffix_start = str.size() - suffix.size();
+        const auto result = str.find(suffix, suffix_start);
+        return (result == suffix_start) && (result != std::string::npos);
     }
 
     /**
@@ -318,7 +318,7 @@ namespace strutil
      */
     static inline bool starts_with(const std::string & str, const std::string & prefix)
     {
-        return str.find(prefix) == 0;
+        return str.rfind(prefix, 0) == 0;
     }
 
     /**
@@ -350,8 +350,8 @@ namespace strutil
         }
 
         // Match semantics of split(str,str)
-        if (str.size() == 0 || ends_with(str, delim)) {
-            tokens.push_back("");
+        if (str.empty() || ends_with(str, delim)) {
+            tokens.emplace_back();
         }
 
         return tokens;

--- a/strutil.h
+++ b/strutil.h
@@ -307,7 +307,7 @@ namespace strutil
      */
     static inline bool ends_with(const std::string & str, const char suffix)
     {
-        return (str.size() > 0) && (*(str.end()-1) == suffix);
+        return !str.empty() && (str.back() == suffix);
     }
 
     /**
@@ -329,7 +329,7 @@ namespace strutil
      */
     static inline bool starts_with(const std::string & str, const char prefix)
     {
-        return (str.size() > 0) && (str[0] == prefix);
+        return !str.empty() && (str.front() == prefix);
     }
 
     /**
@@ -408,7 +408,7 @@ namespace strutil
      * @param rgx_str - the set of delimiter characters.
      * @return True if the parsing is successfully done.
      */
-    static inline std::map<std::string, std::string> regex_split_map(const std::string& src, std::string rgx_str)
+    static inline std::map<std::string, std::string> regex_split_map(const std::string& src, const std::string& rgx_str)
     {
         std::map<std::string, std::string> dest;
         std::string tstr = src + " ";
@@ -484,8 +484,7 @@ namespace strutil
      */
     static inline void drop_empty(std::vector<std::string> & tokens)
     {
-        auto last = std::remove_if(tokens.begin(), tokens.end(),
-                                   [](const std::string& s){ return s.size() == 0; });
+        auto last = std::remove_if(tokens.begin(), tokens.end(), [](const std::string& s){ return s.empty(); });
         tokens.erase(last, tokens.end());
     }
 

--- a/strutil.h
+++ b/strutil.h
@@ -101,7 +101,10 @@ namespace strutil
     static inline std::string capitalize(const std::string & str)
     {
         auto result = str;
-        result[0] = std::toupper(result[0]);
+        if (!result.empty())
+        {
+            result.front() = static_cast<char>(std::toupper(result.front()));
+        }
 
         return result;
     }
@@ -114,7 +117,10 @@ namespace strutil
     static inline std::string capitalize_first_char(const std::string & str)
     {
         auto result = to_lower(str);
-        result[0] = std::toupper(result[0]);
+        if (!result.empty())
+        {
+            result.front() = static_cast<char>(std::toupper(result.front()));
+        }
 
         return result;
     }
@@ -138,7 +144,7 @@ namespace strutil
      */
     static inline bool contains(const std::string & str, const char character)
     {
-        return contains(str, std::string(1,character));
+        return contains(str, std::string(1, character));
     }
 
     /**
@@ -224,18 +230,18 @@ namespace strutil
      *        Taken from: http://stackoverflow.com/questions/3418231/c-replace-part-of-a-string-with-another-string.
      * @param str - input std::string that will be modified.
      * @param target - substring that will be replaced with replacement.
-     * @param replecament - substring that will replace target.
+     * @param replacement - substring that will replace target.
      * @return True if replacement was successfull, false otherwise.
      */
-    static inline bool replace_first(std::string & str, const std::string & target, const std::string & replecament)
+    static inline bool replace_first(std::string & str, const std::string & target, const std::string & replacement)
     {
-        size_t start_pos = str.find(target);
+        const size_t start_pos = str.find(target);
         if (start_pos == std::string::npos)
         {
             return false;
         }
 
-        str.replace(start_pos, target.length(), replecament);
+        str.replace(start_pos, target.length(), replacement);
         return true;
     }
 
@@ -244,10 +250,10 @@ namespace strutil
      *        Taken from: http://stackoverflow.com/questions/3418231/c-replace-part-of-a-string-with-another-string.
      * @param str - input std::string that will be modified.
      * @param target - substring that will be replaced with replacement.
-     * @param replecament - substring that will replace target.
+     * @param replacement - substring that will replace target.
      * @return True if replacement was successfull, false otherwise.
      */
-    static inline bool replace_last(std::string & str, const std::string & target, const std::string & replecament)
+    static inline bool replace_last(std::string & str, const std::string & target, const std::string & replacement)
     {
         size_t start_pos = str.rfind(target);
         if (start_pos == std::string::npos)
@@ -255,7 +261,7 @@ namespace strutil
             return false;
         }
 
-        str.replace(start_pos, target.length(), replecament);
+        str.replace(start_pos, target.length(), replacement);
         return true;
     }
 
@@ -264,10 +270,10 @@ namespace strutil
      *        Taken from: http://stackoverflow.com/questions/3418231/c-replace-part-of-a-string-with-another-string.
      * @param str - input std::string that will be modified.
      * @param target - substring that will be replaced with replacement.
-     * @param replecament - substring that will replace target.
+     * @param replacement - substring that will replace target.
      * @return True if replacement was successfull, false otherwise.
      */
-    static inline bool replace_all(std::string & str, const std::string & target, const std::string & replecament)
+    static inline bool replace_all(std::string & str, const std::string & target, const std::string & replacement)
     {
         if (target.empty())
         {
@@ -279,8 +285,8 @@ namespace strutil
 
         while ((start_pos = str.find(target, start_pos)) != std::string::npos)
         {
-            str.replace(start_pos, target.length(), replecament);
-            start_pos += replecament.length();
+            str.replace(start_pos, target.length(), replacement);
+            start_pos += replacement.length();
         }
 
         return found_substring;
@@ -387,10 +393,10 @@ namespace strutil
      * @param rgx_str - the set of delimiter characters.
      * @return vector of resulting tokens.
      */
-    static inline std::vector<std::string> regex_split(const std::string& src, std::string rgx_str)
+    static inline std::vector<std::string> regex_split(const std::string& src, const std::string& rgx_str)
     {
         std::vector<std::string> elems;
-        std::regex rgx(rgx_str);
+        const std::regex rgx(rgx_str);
         std::sregex_token_iterator iter(src.begin(), src.end(), rgx, -1);
         std::sregex_token_iterator end;
         while (iter != end)

--- a/tests/test_cases.cpp
+++ b/tests/test_cases.cpp
@@ -24,9 +24,13 @@ TEST(Compare, starts_with_str)
 {
     EXPECT_EQ(true, strutil::starts_with("m_DiffuseTexture", "m_"));
     EXPECT_EQ(true, strutil::starts_with("This is a simple test case", "This "));
+    EXPECT_EQ(true, strutil::starts_with("This is a simple test case", "This is a simple test case"));
+    EXPECT_EQ(true, strutil::starts_with("", ""));
 
     EXPECT_EQ(false, strutil::starts_with("p_DiffuseTexture", "m_"));
     EXPECT_EQ(false, strutil::starts_with("This is a simple test case", "his "));
+    EXPECT_EQ(false, strutil::starts_with("abc", "abc_"));
+    EXPECT_EQ(false, strutil::starts_with("abc", "_abc"));
 
     EXPECT_EQ(false, strutil::starts_with("", "m_"));
 }
@@ -46,9 +50,13 @@ TEST(Compare, ends_with_str)
 {
     EXPECT_EQ(true, strutil::ends_with("DiffuseTexture_m", "_m"));
     EXPECT_EQ(true, strutil::ends_with("This is a simple test case", " test case"));
+    EXPECT_EQ(true, strutil::ends_with("This is a simple test case", "This is a simple test case"));
+    EXPECT_EQ(true, strutil::ends_with("", ""));
 
     EXPECT_EQ(false, strutil::ends_with("DiffuseTexture_p", "_m"));
     EXPECT_EQ(false, strutil::ends_with("This is a simple test case", "test cas"));
+    EXPECT_EQ(false, strutil::ends_with("abc", "_abc"));
+    EXPECT_EQ(false, strutil::ends_with("abc", "abc_"));
 
     EXPECT_EQ(false, strutil::ends_with("", "_m"));
 }
@@ -67,13 +75,17 @@ TEST(Compare, ends_with_char)
 TEST(Compare, contains_str)
 {
     EXPECT_EQ(true, strutil::contains("DiffuseTexture_m", "fuse"));
+    EXPECT_EQ(true, strutil::contains("", ""));
     EXPECT_EQ(false, strutil::contains("DiffuseTexture_m", "fuser"));
+    EXPECT_EQ(false, strutil::contains("abc", "abc_"));
+    EXPECT_EQ(false, strutil::contains("", "abc"));
 }
 
 TEST(Compare, contains_char)
 {
     EXPECT_EQ(true, strutil::contains("DiffuseTexture_m", 'f'));
     EXPECT_EQ(false, strutil::contains("DiffuseTexture_m", 'z'));
+    EXPECT_EQ(false, strutil::contains("", 'z'));
 }
 
 TEST(Compare, matches)

--- a/tests/test_cases.cpp
+++ b/tests/test_cases.cpp
@@ -507,18 +507,21 @@ TEST(TextManip, to_lower)
 TEST(TextManip, to_upper)
 {
     EXPECT_EQ("HELLO STRUTIL", strutil::to_upper("HeLlo StRUTIL"));
+    EXPECT_EQ("", strutil::to_upper(""));
 }
 
 TEST(TextManip, capitalize)
 {
     EXPECT_EQ("HeLlo StRUTIL", strutil::capitalize("heLlo StRUTIL"));
     EXPECT_EQ("+ is an operator.", strutil::capitalize("+ is an operator."));
+    EXPECT_EQ("", strutil::capitalize(""));
 }
 
 TEST(TextManip, capitalize_first_char)
 {
     EXPECT_EQ("Hello strutil", strutil::capitalize_first_char("HeLlo StRUTIL"));
     EXPECT_EQ("+ is an operator.", strutil::capitalize_first_char("+ is an operator."));
+    EXPECT_EQ("", strutil::capitalize_first_char(""));
 }
 
 TEST(TextManip, trim_left_in_place)


### PR DESCRIPTION
`str.size() == 0` replaced with `str.empty()` in multiple places; added a few corner cases for tests; significantly improved `.starts_with()` and `.ends_with()` functions performance:
```cpp
bool starts_with("ZZZZZZZZZZZabcZZZ", "abc") {
    return str.rfind(prefix, 0) == 0; // by doing rfind(*, 0), we don't go through the entire string and only compare the prefix
}
```